### PR TITLE
MOD: OSGi manifest headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.thethingsnetwork</groupId>
     <artifactId>java-app-lib</artifactId>
     <version>0.2.0</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -119,6 +119,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -120,10 +120,10 @@
                 </executions>
             </plugin>
             <plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-			</plugin>
+		<groupId>org.apache.felix</groupId>
+		<artifactId>maven-bundle-plugin</artifactId>
+		<extensions>true</extensions>
+	    </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Introduced bundle packaging through maven-bundle-plugin.

java-app-lib solely depends on org.eclipse.paho/org.eclipse.paho.client.mqttv3 and org.json/json: both this artifacts are built as [Java OSGi bundles](https://en.wikipedia.org/wiki/OSGi#Bundles).

I have added the maven-bundle-plugin to the POM and changed the packaging mode to "bundle": this way the generated JAR has all the needed manifest headers to be a proper OSGi bundle itself.

The usage of the JAR as a simple standalone Java library is totally unchanged, but now the same library can properly execute inside an OSGi runtime, like [Apache Felix](http://felix.apache.org/), [Eclipse Equinox](https://www.eclipse.org/equinox/) and so on.